### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "reactjs"
+run = "npm install"

--- a/README.md
+++ b/README.md
@@ -28,3 +28,5 @@ You will need a companion PHP server to communicate with Watson and Twitter API.
 ![alt text](http://personality-insights.shahabqamar.com/screenshots/twitter.png "Twitter feed input")
 
 ![alt text](http://personality-insights.shahabqamar.com/screenshots/results.png "Raw text input")
+
+[![Run on Repl.it](https://repl.it/badge/github/shahabqamar/ibm-personality-insights)](https://repl.it/github/shahabqamar/ibm-personality-insights)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@EduardoPunto/ibm-personality-insights).